### PR TITLE
Remove ballerina-system dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ ext.stdlibCryptoVersion = project.stdlibCryptoVersion
 ext.stdlibLogVersion = project.stdlibLogVersion
 ext.stdlibTimeVersion = project.stdlibTimeVersion
 ext.stdlibRuntimeVersion = project.stdlibRuntimeVersion
-ext.stdlibSystemVersion = project.stdlibSystemVersion
 ext.stdlibIoVersion = project.stdlibIoVersion
 
 allprojects {
@@ -103,14 +102,6 @@ allprojects {
             }
         }
 
-        maven {
-            url "https://maven.pkg.github.com/ballerina-platform/module-ballerina-system"
-            credentials {
-                username System.getenv("packageUser")
-                password System.getenv("packagePAT")
-            }
-        }
-
     }
 }
 
@@ -126,7 +117,6 @@ subprojects {
         ballerinaStdLibs "org.ballerinalang:crypto-ballerina:${stdlibCryptoVersion}"
         ballerinaStdLibs "org.ballerinalang:time-ballerina:${stdlibTimeVersion}"
         ballerinaStdLibs "org.ballerinalang:runtime-ballerina:${stdlibRuntimeVersion}"
-        ballerinaStdLibs "org.ballerinalang:system-ballerina:${stdlibSystemVersion}"
         ballerinaStdLibs "org.ballerinalang:io-ballerina:${stdlibIoVersion}"
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,6 @@ puppycrawlCheckstyleVersion=8.18
 stdlibCryptoVersion=1.0.5-SNAPSHOT
 stdlibLogVersion=1.0.5-SNAPSHOT
 stdlibTimeVersion=1.0.6-SNAPSHOT
-stdlibSystemVersion=0.6.5-SNAPSHOT
 stdlibRuntimeVersion=0.5.5-SNAPSHOT
 stdlibIoVersion=0.5.5-SNAPSHOT
 natsVersion=2.8.0


### PR DESCRIPTION
## Purpose
Remove ballerina-system dependency. It is not used as a direct or a transitive dependency anymore. 