### PR TITLE
Update SecureSocket record 

### DIFF
--- a/nats-ballerina/records.bal
+++ b/nats-ballerina/records.bal
@@ -54,16 +54,25 @@ public type Credentials record {|
   string password;
 |};
 
-# Configurations related to facilitating a secure communication with a remote HTTP endpoint.
+# Configurations related to facilitating a secure communication.
 #
-# + trustStore - Configurations associated with the TrustStore
-# + keyStore - Configurations associated with the KeyStore
-# + protocol - The standard name of the requested protocol
+# + cert - Configurations associated with `crypto:TrustStore`
+# + key - Configurations associated with `crypto:KeyStore`
+# + protocol - SSL/TLS protocol related options
 public type SecureSocket record {|
-    crypto:TrustStore trustStore?;
-    crypto:KeyStore keyStore?;
-    string protocol = "TLS";
+    crypto:TrustStore cert;
+    crypto:KeyStore key?;
+    record {|
+        Protocol name;
+    |} protocol?;
 |};
+
+# Represents protocol options.
+public enum Protocol {
+   SSL,
+   TLS,
+   DTLS
+}
 
 # Configurations related to pinging the server
 #

--- a/nats-native/src/main/java/org/ballerinalang/nats/Constants.java
+++ b/nats-native/src/main/java/org/ballerinalang/nats/Constants.java
@@ -61,9 +61,10 @@ public class Constants {
     public static final String NATS_CLIENT_UNSUBSCRIBED = "[ballerina/nats] Client unsubscribed from subject ";
 
     public static final BString CONNECTION_CONFIG_SECURE_SOCKET = StringUtils.fromString("secureSocket");
-    public static final BString CONNECTION_KEYSTORE = StringUtils.fromString("keyStore");
-    public static final BString CONNECTION_TRUSTORE = StringUtils.fromString("trustStore");
+    public static final BString CONNECTION_KEYSTORE = StringUtils.fromString("key");
+    public static final BString CONNECTION_TRUSTORE = StringUtils.fromString("cert");
     public static final BString CONNECTION_PROTOCOL = StringUtils.fromString("protocol");
+    public static final BString CONNECTION_PROTOCOL_NAME = StringUtils.fromString("name");
     public static final String KEY_STORE_TYPE = "PKCS12";
     public static final BString KEY_STORE_PASS = StringUtils.fromString("password");
     public static final BString KEY_STORE_PATH = StringUtils.fromString("path");

--- a/nats-native/src/main/java/org/ballerinalang/nats/connection/ConnectionUtils.java
+++ b/nats-native/src/main/java/org/ballerinalang/nats/connection/ConnectionUtils.java
@@ -37,6 +37,7 @@ import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.time.Duration;

--- a/nats-native/src/main/java/org/ballerinalang/nats/connection/ConnectionUtils.java
+++ b/nats-native/src/main/java/org/ballerinalang/nats/connection/ConnectionUtils.java
@@ -193,7 +193,7 @@ public class ConnectionUtils {
             sslContext = SSLContext.getDefault();
         }
         sslContext.init(keyManagerFactory != null ? keyManagerFactory.getKeyManagers() : null,
-                         trustManagerFactory.getTrustManagers(), null);
+                         trustManagerFactory.getTrustManagers(), new SecureRandom());
         return sslContext;
     }
 }

--- a/nats-native/src/main/java/org/ballerinalang/nats/connection/ConnectionUtils.java
+++ b/nats-native/src/main/java/org/ballerinalang/nats/connection/ConnectionUtils.java
@@ -165,7 +165,6 @@ public class ConnectionUtils {
         @SuppressWarnings("unchecked")
         BMap<BString, Object> cryptoTrustStore =
                 (BMap<BString, Object>) secureSocket.getMapValue(Constants.CONNECTION_TRUSTORE);
-        TrustManagerFactory trustManagerFactory;
         KeyStore trustStore = KeyStore.getInstance(Constants.KEY_STORE_TYPE);
         char[] trustPassphrase = cryptoTrustStore.getStringValue(Constants.KEY_STORE_PASS).getValue()
                 .toCharArray();
@@ -178,25 +177,20 @@ public class ConnectionUtils {
             throw Utils.createNatsError(Constants.ERROR_SETTING_UP_SECURED_CONNECTION
                                                 + "truststore path doesn't exist.");
         }
-        trustManagerFactory =
+        TrustManagerFactory trustManagerFactory =
                 TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
         trustManagerFactory.init(trustStore);
 
         // protocol
-        String protocol = null;
+        SSLContext sslContext;
         if (secureSocket.containsKey(Constants.CONNECTION_PROTOCOL)) {
             @SuppressWarnings("unchecked")
             BMap<BString, Object> protocolRecord =
                     (BMap<BString, Object>) secureSocket.getMapValue(Constants.CONNECTION_PROTOCOL);
-            protocol = protocolRecord.getStringValue(Constants.CONNECTION_PROTOCOL_NAME).getValue();
-        }
-
-        // SSL Context
-        SSLContext sslContext;
-        if (protocol == null) {
-            sslContext = SSLContext.getDefault();
-        } else {
+            String protocol = protocolRecord.getStringValue(Constants.CONNECTION_PROTOCOL_NAME).getValue();
             sslContext = SSLContext.getInstance(protocol);
+        } else {
+            sslContext = SSLContext.getDefault();
         }
         sslContext.init(keyManagerFactory != null ? keyManagerFactory.getKeyManagers() : null,
                          trustManagerFactory.getTrustManagers(), null);

--- a/nats-native/src/main/java/org/ballerinalang/nats/connection/ConnectionUtils.java
+++ b/nats-native/src/main/java/org/ballerinalang/nats/connection/ConnectionUtils.java
@@ -136,12 +136,15 @@ public class ConnectionUtils {
      * @param secureSocket secureSocket record.
      * @return Initialized SSLContext.
      */
-    private static SSLContext getSSLContext(BMap secureSocket)
+    private static SSLContext getSSLContext(BMap<BString, Object> secureSocket)
             throws IOException, CertificateException, NoSuchAlgorithmException, KeyStoreException,
                    UnrecoverableKeyException, KeyManagementException {
-        BMap cryptoKeyStore = secureSocket.getMapValue(Constants.CONNECTION_KEYSTORE);
+        // Keystore
         KeyManagerFactory keyManagerFactory = null;
-        if (cryptoKeyStore != null) {
+        if (secureSocket.containsKey(Constants.CONNECTION_KEYSTORE)) {
+            @SuppressWarnings("unchecked")
+            BMap<BString, Object> cryptoKeyStore =
+                    (BMap<BString, Object>) secureSocket.getMapValue(Constants.CONNECTION_KEYSTORE);
             char[] keyPassphrase = cryptoKeyStore.getStringValue(Constants.KEY_STORE_PASS).getValue().toCharArray();
             String keyFilePath = cryptoKeyStore.getStringValue(Constants.KEY_STORE_PATH).getValue();
             KeyStore keyStore = KeyStore.getInstance(Constants.KEY_STORE_TYPE);
@@ -158,30 +161,45 @@ public class ConnectionUtils {
             keyManagerFactory.init(keyStore, keyPassphrase);
         }
 
-        BMap cryptoTrustStore = secureSocket.getMapValue(Constants.CONNECTION_TRUSTORE);
-        TrustManagerFactory trustManagerFactory = null;
-        if (cryptoTrustStore != null) {
-            KeyStore trustStore = KeyStore.getInstance(Constants.KEY_STORE_TYPE);
-            char[] trustPassphrase = cryptoTrustStore.getStringValue(Constants.KEY_STORE_PASS).getValue()
-                    .toCharArray();
-            String trustFilePath = cryptoTrustStore.getStringValue(Constants.KEY_STORE_PATH).getValue();
-            if (trustFilePath != null) {
-                try (FileInputStream trustFileInputStream = new FileInputStream(trustFilePath)) {
-                    trustStore.load(trustFileInputStream, trustPassphrase);
-                }
-            } else {
-                throw Utils.createNatsError(Constants.ERROR_SETTING_UP_SECURED_CONNECTION
-                                                    + "truststore path doesn't exist.");
+        // Truststore
+        @SuppressWarnings("unchecked")
+        BMap<BString, Object> cryptoTrustStore =
+                (BMap<BString, Object>) secureSocket.getMapValue(Constants.CONNECTION_TRUSTORE);
+        TrustManagerFactory trustManagerFactory;
+        KeyStore trustStore = KeyStore.getInstance(Constants.KEY_STORE_TYPE);
+        char[] trustPassphrase = cryptoTrustStore.getStringValue(Constants.KEY_STORE_PASS).getValue()
+                .toCharArray();
+        String trustFilePath = cryptoTrustStore.getStringValue(Constants.KEY_STORE_PATH).getValue();
+        if (trustFilePath != null) {
+            try (FileInputStream trustFileInputStream = new FileInputStream(trustFilePath)) {
+                trustStore.load(trustFileInputStream, trustPassphrase);
             }
-            trustManagerFactory =
-                    TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-            trustManagerFactory.init(trustStore);
+        } else {
+            throw Utils.createNatsError(Constants.ERROR_SETTING_UP_SECURED_CONNECTION
+                                                + "truststore path doesn't exist.");
+        }
+        trustManagerFactory =
+                TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        trustManagerFactory.init(trustStore);
+
+        // protocol
+        String protocol = null;
+        if (secureSocket.containsKey(Constants.CONNECTION_PROTOCOL)) {
+            @SuppressWarnings("unchecked")
+            BMap<BString, Object> protocolRecord =
+                    (BMap<BString, Object>) secureSocket.getMapValue(Constants.CONNECTION_PROTOCOL);
+            protocol = protocolRecord.getStringValue(Constants.CONNECTION_PROTOCOL_NAME).getValue();
         }
 
-        String tlsVersion = secureSocket.getStringValue(Constants.CONNECTION_PROTOCOL).getValue();
-        SSLContext sslContext = SSLContext.getInstance(tlsVersion);
+        // SSL Context
+        SSLContext sslContext;
+        if (protocol == null) {
+            sslContext = SSLContext.getDefault();
+        } else {
+            sslContext = SSLContext.getInstance(protocol);
+        }
         sslContext.init(keyManagerFactory != null ? keyManagerFactory.getKeyManagers() : null,
-                        trustManagerFactory != null ? trustManagerFactory.getTrustManagers() : null, null);
+                         trustManagerFactory.getTrustManagers(), null);
         return sslContext;
     }
 }


### PR DESCRIPTION
## Purpose
This updates the `SecureSocket` record to be used in client configurations. 
Updated record definition:
```ballerina
# Configurations related to facilitating secure communication with a remote HTTP endpoint.
#
# + cert - Configurations associated with `crypto:TrustStore`
# + key - Configurations associated with `crypto:KeyStore`
# + protocol - SSL/TLS protocol related options
public type SecureSocket record {|
    crypto:TrustStore cert;
    crypto:KeyStore key?;
    record {|
        Protocol name;
    |} protocol?;
|};

public enum Protocol {
   SSL,
   TLS,
   DTLS
}
```