### PR TITLE
NATS package updates for Swan Lake alpha4 

### DIFF
--- a/nats-ballerina/Package.md
+++ b/nats-ballerina/Package.md
@@ -65,13 +65,13 @@ nats:Error? result = natsClient->publish({ content: message.toBytes(), subject: 
 ##### Listening to messages from a NATS server
 
 ```ballerina
-// Binds the consumer to listen to the messages published to the 'demo' subject.
+// Binds the consumer to listen to the messages published to the 'demo.example.*' subject.
 @nats:ServiceConfig {
-    subject: "demo"
+    subject: "demo.example.*"
 }
-service demo on new nats:Listener() {
+service nats:Service on new nats:Listener(nats:DEFAULT_URL) {
 
-    remote function onMessage(nats:Message msg) {
+    remote function onMessage(nats:Message message) {
     }
 }
 ```

--- a/nats-ballerina/Package.md
+++ b/nats-ballerina/Package.md
@@ -27,8 +27,8 @@ nats:Client natsClient = new("nats://serverone:4222");
 3. Connect to one or more servers with custom configurations 
 ```ballerina
 nats:ConnectionConfiguration config = {
-    connectionName = "my-nats",
-    noEcho = true
+    connectionName: "my-nats",
+    noEcho: true
 };
 nats:Client natsClient = new(["nats://serverone:4222",  "nats://servertwo:4222"],  config);
 ```

--- a/nats-ballerina/Package.md
+++ b/nats-ballerina/Package.md
@@ -14,14 +14,23 @@ below functionalities.
 First step is setting up the connection with the NATS Basic server. The following ways can be used to connect to a
 NATS Basic server.
 
-1. Connect to a server using the URL
+1. Connect to a server using the default URL
 ```ballerina
-nats:Client natsClient = new("nats://localhost:4222");
+nats:Client natsClient = new(nats:DEFAULT_URL);
 ```
 
-2. Connect to one or more servers with a custom configuration
+2. Connect to a server using the URL
 ```ballerina
-nats:Client natsClient = new({"nats://serverone:4222",  "nats://servertwo:4222"},  config);
+nats:Client natsClient = new("nats://serverone:4222");
+```
+
+3. Connect to one or more servers with custom configurations 
+```ballerina
+nats:ConnectionConfiguration config = {
+    connectionName = "my-nats",
+    noEcho = true
+};
+nats:Client natsClient = new(["nats://serverone:4222",  "nats://servertwo:4222"],  config);
 ```
 
 #### Publishing messages

--- a/nats-ballerina/Package.md
+++ b/nats-ballerina/Package.md
@@ -50,7 +50,7 @@ nats:Error? result =
 ```ballerina
 string message = "hello world";
 nats:Message|nats:Error reqReply = 
-    natsClient->requestMessage({ content: message.toBytes(), subject: "demo.nats.basic"}, 5000);
+    natsClient->requestMessage({ content: message.toBytes(), subject: "demo.nats.basic"}, 5);
 ```
 
 3. Publish messages with a replyTo subject 

--- a/nats-ballerina/client.bal
+++ b/nats-ballerina/client.bal
@@ -45,9 +45,9 @@ public client class Client {
     # ```
     #
     # + message - Message to be published
-    # + duration - The time (in milliseconds) to wait for the response
+    # + duration - The time (in seconds) to wait for the response
     # + return -  The `nats:Message` response or else a `nats:Error` if an error is encountered
-    isolated remote function requestMessage(Message message, int? duration = ())
+    isolated remote function requestMessage(Message message, decimal? duration = ())
             returns Message|Error {
         return externRequest(self, message.subject, message.content, duration);
     }
@@ -70,7 +70,7 @@ isolated function closeConnection(Client clientObj) returns Error? =
     'class: "org.ballerinalang.nats.basic.client.CloseConnection"
 } external;
 
-isolated function externRequest(Client clientObj, string subject, byte[] data, int? duration = ())
+isolated function externRequest(Client clientObj, string subject, byte[] data, decimal? duration = ())
 returns Message | Error = @java:Method {
     'class: "org.ballerinalang.nats.basic.client.Request"
 } external;

--- a/nats-ballerina/client.bal
+++ b/nats-ballerina/client.bal
@@ -22,9 +22,10 @@ public client class Client {
 
     # Creates a new `nats:Client`.
     #
+    # + url - The NATS Broker URL. For a clustered use case, provide the URLs as a string array
     # + config - Configurations associated with the NATS client to establish a connection with the server
-    public isolated function init(*ConnectionConfiguration config) returns Error? {
-        return clientInit(self, config);
+    public isolated function init(string|string[] url, *ConnectionConfiguration config) returns Error? {
+        return clientInit(self, url, config);
     }
 
     # Publishes data to a given subject.
@@ -59,7 +60,7 @@ public client class Client {
     }
 }
 
-isolated function clientInit(Client clientObj, *ConnectionConfiguration config) returns Error? =
+isolated function clientInit(Client clientObj, string|string[] url, *ConnectionConfiguration config) returns Error? =
 @java:Method {
     'class: "org.ballerinalang.nats.basic.client.Init"
 } external;

--- a/nats-ballerina/listener.bal
+++ b/nats-ballerina/listener.bal
@@ -22,9 +22,10 @@ public class Listener {
 
     # Creates a new NATS Listener.
     #
+    # + url - The NATS Broker URL. For a clustered use case, provide the URLs as a string array
     # + connection - An established NATS connection.
-    public isolated function init(*ConnectionConfiguration config) returns Error? {
-        return consumerInit(self, config);
+    public isolated function init(string|string[] url, *ConnectionConfiguration config) returns Error? {
+        return consumerInit(self, url, config);
     }
 
     # Binds a service to the `nats:Listener`.
@@ -91,7 +92,7 @@ isolated function basicImmediateStop(Listener lis) =
     'class: "org.ballerinalang.nats.basic.consumer.ImmediateStop"
 } external;
 
-isolated function consumerInit(Listener lis, *ConnectionConfiguration config) returns Error? =
+isolated function consumerInit(Listener lis, string|string[] url, *ConnectionConfiguration config) returns Error? =
 @java:Method {
     'class: "org.ballerinalang.nats.basic.consumer.Init"
 } external;

--- a/nats-ballerina/records.bal
+++ b/nats-ballerina/records.bal
@@ -28,7 +28,6 @@ import ballerina/crypto;
 #            has subscriptions on the subject being published to
 # + secureSocket - Configurations related to SSL/TLS
 public type ConnectionConfiguration record {|
-  string|string[] url = DEFAULT_URL;
   string connectionName = "ballerina-nats";
   RetryConfig retryConfig?;
   Ping ping?;

--- a/nats-ballerina/tests/nats_basic_server_tests.bal
+++ b/nats-ballerina/tests/nats_basic_server_tests.bal
@@ -30,7 +30,7 @@ string receivedReplyMessage = "";
 
 @test:BeforeSuite
 function setup() {
-    Client newClient = checkpanic new;
+    Client newClient = checkpanic new(DEFAULT_URL);
     clientObj = newClient;
 }
 
@@ -69,7 +69,7 @@ public function testConsumerService() {
     string message = "Testing Consumer Service";
     Client? newClient = clientObj;
     if (newClient is Client) {
-        Listener sub = checkpanic new;
+        Listener sub = checkpanic new(DEFAULT_URL);
         checkpanic sub.attach(consumerService);
         checkpanic sub.'start();
         checkpanic newClient->publishMessage({ content: message.toBytes(), subject: SERVICE_SUBJECT_NAME });
@@ -88,7 +88,7 @@ public function testOnRequest1() {
     string message = "Hello from the other side!";
     Client? newClient = clientObj;
     if (newClient is Client) {
-        Listener sub = checkpanic new;
+        Listener sub = checkpanic new(DEFAULT_URL);
         checkpanic sub.attach(onRequestService);
         checkpanic sub.attach(onReplyService);
         checkpanic sub.'start();
@@ -110,7 +110,7 @@ public function testOnRequest2() {
     string message = "Hey There Delilah!";
     Client? newClient = clientObj;
     if (newClient is Client) {
-        Listener sub = checkpanic new;
+        Listener sub = checkpanic new(DEFAULT_URL);
         checkpanic sub.attach(onRequestService);
         checkpanic sub.'start();
         Message replyMessage =

--- a/nats-ballerina/types.bal
+++ b/nats-ballerina/types.bal
@@ -18,9 +18,7 @@
 public const string DEFAULT_URL = "nats://localhost:4222";
 
 # The NATS service type
-public type Service service object {
-    remote function onMessage(Message message);
-};
+public type Service service object {};
 
 # The annotation, which is used to configure the basic subscription.
 public annotation ServiceConfigData ServiceConfig on service, class;

--- a/nats-native/src/main/java/org/ballerinalang/nats/basic/client/Init.java
+++ b/nats-native/src/main/java/org/ballerinalang/nats/basic/client/Init.java
@@ -40,10 +40,10 @@ import java.security.cert.CertificateException;
  */
 public class Init {
 
-    public static Object clientInit(BObject clientObj, BMap connectionConfig) {
+    public static Object clientInit(BObject clientObj, Object url, BMap connectionConfig) {
         Connection natsConnection;
         try {
-            natsConnection = ConnectionUtils.getNatsConnection(connectionConfig);
+            natsConnection = ConnectionUtils.getNatsConnection(url, connectionConfig);
         } catch (UnrecoverableKeyException e) {
             return Utils.createNatsError(
                     Constants.ERROR_SETTING_UP_SECURED_CONNECTION + "The key in the keystore cannot be recovered.");

--- a/nats-native/src/main/java/org/ballerinalang/nats/basic/consumer/Init.java
+++ b/nats-native/src/main/java/org/ballerinalang/nats/basic/consumer/Init.java
@@ -47,10 +47,10 @@ import static org.ballerinalang.nats.Constants.DISPATCHER_LIST;
  */
 public class Init {
 
-    public static Object consumerInit(BObject listenerObject, BMap connectionConfig) {
+    public static Object consumerInit(BObject listenerObject, Object url, BMap connectionConfig) {
         Connection natsConnection = null;
         try {
-            natsConnection = ConnectionUtils.getNatsConnection(connectionConfig);
+            natsConnection = ConnectionUtils.getNatsConnection(url, connectionConfig);
         } catch (UnrecoverableKeyException e) {
             return Utils.createNatsError(
                     Constants.ERROR_SETTING_UP_SECURED_CONNECTION + "The key in the keystore cannot be recovered.");

--- a/nats-native/src/main/java/org/ballerinalang/nats/connection/ConnectionUtils.java
+++ b/nats-native/src/main/java/org/ballerinalang/nats/connection/ConnectionUtils.java
@@ -64,13 +64,11 @@ public class ConnectionUtils {
     private static final BString USERNAME = StringUtils.fromString("username");
     private static final BString PASSWORD = StringUtils.fromString("password");
     private static final BString TOKEN = StringUtils.fromString("token");
-    private static final BString URLS = StringUtils.fromString("url");
 
-    public static Connection getNatsConnection(BMap connectionConfig)
+    public static Connection getNatsConnection(Object urlString, BMap connectionConfig)
             throws UnrecoverableKeyException, CertificateException, NoSuchAlgorithmException, KeyStoreException,
                    KeyManagementException, IOException, InterruptedException {
         Options.Builder opts = new Options.Builder();
-        Object urlString = connectionConfig.get(URLS);
         if (TypeUtils.getType(urlString).getTag() == TypeTags.ARRAY_TAG) {
             String[] serverUrls = ((BArray) urlString).getStringArray();
             opts.servers(serverUrls);


### PR DESCRIPTION
Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/1175 

## Changes:
1. Remove onMessage from the service definition in the package **[Not Breaking]**
2. Client and listener init change **[Breaking]** 
```ballerina
// old syntax
nats:Client natsClient = check new;
nats:Client natsClient = check new(url = "nats://localhost:4222");

// new syntax - URL is not defaultable, it is mandatory
nats:Client natsClient = check new(nats:DEFAULT_URL);
nats:Client natsClient = check new("nats://localhost:4222");

// in both can pass remaining config values as named args
```
3. Change `duration` in `requestMessage()` to `decimal` **[Breaking]**