### PR TITLE
Fix Release Script, Increase Trivy Scan Timeout, and Migrate to CodeCov V2

### DIFF
--- a/.github/workflows/build-timestamped-master.yml
+++ b/.github/workflows/build-timestamped-master.yml
@@ -37,4 +37,4 @@ jobs:
         run: |
           ./gradlew publish --scan --no-daemon
       - name: Generate Codecov Report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2

--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -26,6 +26,7 @@ jobs:
                   scan-type: 'fs'
                   scan-ref: '/github/workspace/ballerina/lib'
                   format: 'table'
+                  timeout: '10m0s'
                   exit-code: '1'
             - name: Publish artifact
               env:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,7 +21,10 @@ jobs:
               env:
                   packageUser: ${{ github.actor }}
                   packagePAT: ${{ secrets.GITHUB_TOKEN }}
-              run: ./gradlew build -x check -x test
+              run: |
+                  git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
+                  git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
+                  ./gradlew build -x check -x test
             - name: Run Trivy vulnerability scanner
               uses: aquasecurity/trivy-action@master
               with:
@@ -32,13 +35,11 @@ jobs:
                   exit-code: '1'
             - name: Set version env variable
               run: echo "VERSION=$((grep -w 'version' | cut -d= -f2) < gradle.properties | rev | cut --complement -d- -f1 | rev)" >> $GITHUB_ENV
-            - name: Pre release depenency version update
+            - name: Pre release dependency version update
               env:
                   GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
               run: |
                   echo "Version: ${VERSION}"
-                  git config user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
-                  git config user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
                   git checkout -b release-${VERSION}
                   sed -i 's/ballerinaLangVersion=\(.*\)-SNAPSHOT/ballerinaLangVersion=\1/g' gradle.properties
                   sed -i 's/ballerinaLangVersion=\(.*\)-[0-9]\{8\}-[0-9]\{6\}-.*$/ballerinaLangVersion=\1/g' gradle.properties
@@ -55,8 +56,6 @@ jobs:
                   publishUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
                   publishPAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
               run: |
-                  git config user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
-                  git config user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
                   ./gradlew release -Prelease.useAutomaticVersion=true
                   ./gradlew -Pversion=${VERSION} publish -x test -PpublishToCentral=true
             - name: GitHub Release and Release Sync PR

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,7 +21,7 @@ jobs:
               run: ./gradlew build
             - name: Generate Codecov Report
               if: github.event_name == 'pull_request'
-              uses: codecov/codecov-action@v1
+              uses: codecov/codecov-action@v2
 
     windows-build:
         name: Build on Windows

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -27,4 +27,5 @@ jobs:
           scan-type: 'fs'
           scan-ref: '/github/workspace/ballerina/lib'
           format: 'table'
+          timeout: '10m0s'
           exit-code: '1'

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -92,9 +92,9 @@ task commitTomlFiles {
         project.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "git commit Ballerina.toml Dependencies.toml CompilerPlugin.toml -m \"[Automated] Update the native jar versions\""
+                commandLine 'cmd', '/c', "git commit -m '[Automated] Update the native jar versions' Ballerina.toml CompilerPlugin.toml Dependencies.toml"
             } else {
-                commandLine 'sh', '-c', "git commit Ballerina.toml Dependencies.toml CompilerPlugin.toml -m '[Automated] Update the native jar versions'"
+                commandLine 'sh', '-c', "git commit -m '[Automated] Update the native jar versions' Ballerina.toml CompilerPlugin.toml Dependencies.toml"
             }
         }
     }


### PR DESCRIPTION
## Purpose
$title
related to: ballerina-platform/ballerina-standard-library#2033
Fixes:

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
