### PR TITLE
Remove deprecated nats:Message usages

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ nats:Error? result =
 2. Publish as a request that expects a reply:
 ```ballerina
 string message = "hello world";
-nats:Message|nats:Error reqReply = 
+nats:AnydataMessage|nats:Error reqReply = 
     natsClient->requestMessage({ content: message.toBytes(), subject: "demo.nats.basic"}, 5);
 ```
 
@@ -76,7 +76,7 @@ nats:Error? result = natsClient->publish({ content: message.toBytes(), subject: 
 }
 service nats:Service on new nats:Listener(nats:DEFAULT_URL) {
 
-    remote function onMessage(nats:Message message) {
+    remote function onMessage(nats:AnydataMessage message) {
     }
 }
 ```
@@ -90,7 +90,7 @@ service nats:Service on new nats:Listener(nats:DEFAULT_URL) {
 service nats:Service on new nats:Listener(nats:DEFAULT_URL) {
 
     // The returned message will be published to the replyTo subject of the consumed message
-    remote function onRequest(nats:Message message) returns string? {
+    remote function onRequest(nats:AnydataMessage message) returns string? {
         return "Reply Message";
     }
 }

--- a/ballerina-tests/Ballerina.toml
+++ b/ballerina-tests/Ballerina.toml
@@ -1,4 +1,4 @@
 [package]
 org = "ballerinax"
 name = "nats_tests"
-version = "2.11.0"
+version = "3.0.0"

--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "nats"
-version = "2.11.0"
+version = "3.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
@@ -158,7 +158,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "nats_tests"
-version = "2.11.0"
+version = "3.0.0"
 dependencies = [
 	{org = "ballerina", name = "lang.runtime"},
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina-tests/tests/data_binding_publish_tests.bal
+++ b/ballerina-tests/tests/data_binding_publish_tests.bal
@@ -619,7 +619,7 @@ service nats:Service on new nats:Listener(DATA_BINDING_URL) {
     remote function onMessage(XmlMessage msg) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
         log:printInfo("Error Received: " + err.message());
         setOnErrorReceived(true);
         setOnErrorMessage(err.message());

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "nats"
-version = "2.11.0"
+version = "3.0.0"
 authors = ["Ballerina"]
 keywords = ["service", "client", "messaging", "network", "pubsub"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-nats"
@@ -18,8 +18,8 @@ path = "./lib/jnats-2.16.0.jar"
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "nats-native"
-version = "2.11.0"
-path = "../native/build/libs/nats-native-2.11.0-SNAPSHOT.jar"
+version = "3.0.0"
+path = "../native/build/libs/nats-native-3.0.0-SNAPSHOT.jar"
 
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "nats-compiler-plugin"
 class = "io.ballerina.stdlib.nats.plugin.NatsCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/nats-compiler-plugin-2.11.0-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/nats-compiler-plugin-3.0.0-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -160,7 +160,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "nats"
-version = "2.11.0"
+version = "3.0.0"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "crypto"},

--- a/ballerina/Module.md
+++ b/ballerina/Module.md
@@ -46,7 +46,7 @@ nats:Error? result =
 2. Publish as a request that expects a reply:
 ```ballerina
 string message = "hello world";
-nats:Message|nats:Error reqReply = 
+nats:AnydataMessage|nats:Error reqReply = 
     natsClient->requestMessage({ content: message.toBytes(), subject: "demo.nats.basic"}, 5);
 ```
 
@@ -69,7 +69,7 @@ nats:Error? result = natsClient->publish({ content: message.toBytes(), subject: 
 }
 service nats:Service on new nats:Listener(nats:DEFAULT_URL) {
 
-    remote function onMessage(nats:Message message) {
+    remote function onMessage(nats:AnydataMessage message) {
     }
 }
 ```
@@ -83,7 +83,7 @@ service nats:Service on new nats:Listener(nats:DEFAULT_URL) {
 service nats:Service on new nats:Listener(nats:DEFAULT_URL) {
 
     // The returned message will be published to the replyTo subject of the consumed message
-    remote function onRequest(nats:Message message) returns string? {
+    remote function onRequest(nats:AnydataMessage message) returns string? {
         return "Reply Message";
     }
 }

--- a/ballerina/Package.md
+++ b/ballerina/Package.md
@@ -46,7 +46,7 @@ nats:Error? result =
 2. Publish as a request that expects a reply:
 ```ballerina
 string message = "hello world";
-nats:Message|nats:Error reqReply = 
+nats:AnydataMessage|nats:Error reqReply = 
     natsClient->requestMessage({ content: message.toBytes(), subject: "demo.nats.basic"}, 5);
 ```
 
@@ -69,7 +69,7 @@ nats:Error? result = natsClient->publish({ content: message.toBytes(), subject: 
 }
 service nats:Service on new nats:Listener(nats:DEFAULT_URL) {
 
-    remote function onMessage(nats:Message message) {
+    remote function onMessage(nats:AnydataMessage message) {
     }
 }
 ```
@@ -83,7 +83,7 @@ service nats:Service on new nats:Listener(nats:DEFAULT_URL) {
 service nats:Service on new nats:Listener(nats:DEFAULT_URL) {
 
     // The returned message will be published to the replyTo subject of the consumed message
-    remote function onRequest(nats:Message message) returns string? {
+    remote function onRequest(nats:AnydataMessage message) returns string? {
         return "Reply Message";
     }
 }

--- a/ballerina/records.bal
+++ b/ballerina/records.bal
@@ -109,20 +109,6 @@ public type RetryConfig record {|
     decimal connectionTimeout = 2;
 |};
 
-# Represents the message, which a NATS server sends to its subscribed services.
-#
-# + content - The message content
-# + replyTo - The `replyTo` subject of the message
-# + subject - The subject to which the message was sent to
-# # Deprecated
-# This record is deprecated. Use `AnydataMessage` record instead.
-@deprecated
-public type Message record {|
-    byte[] content;
-    string subject;
-    string replyTo?;
-|};
-
 # Represents the anydata message, which a NATS server sends to its subscribed services.
 #
 # + content - The message content, which can of type anydata

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ This file contains all the notable changes done to the Ballerina NATS package th
 
 ### Changed
 
+- [[#6282] Remove the definition and the usages of the deprecated nats:Message record](https://github.com/ballerina-platform/ballerina-library/issues/6282)
+
+## [2.10.0] - 2023-09-18
+
+### Changed
+
 - [[#4733] Changed disallowing service level annotations in the compiler plugin](https://github.com/ballerina-platform/ballerina-standard-library/issues/4733)
 
 ## [2.7.0] - 2023-04-10

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@ This file contains all the notable changes done to the Ballerina NATS package th
 
 ### Changed
 
-- [[#6282] Remove the definition and the usages of the deprecated nats:Message record](https://github.com/ballerina-platform/ballerina-library/issues/6282)
+- [[#6282] Remove the definition and the usages of the deprecated `nats:Message` record](https://github.com/ballerina-platform/ballerina-library/issues/6282)
 
 ## [2.10.0] - 2023-09-18
 

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_10/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_10/service.bal
@@ -23,7 +23,7 @@ listener nats:Listener subscription = new(nats:DEFAULT_URL);
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message msg) returns nats:Client|error {
+    remote function onRequest(nats:AnydataMessage msg) returns nats:Client|error {
         return new nats:Client(nats:DEFAULT_URL);
     }
 }
@@ -33,7 +33,7 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message msg) returns nats:Listener {
+    remote function onRequest(nats:AnydataMessage msg) returns nats:Listener {
         return subscription;
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_11/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_11/service.bal
@@ -23,7 +23,7 @@ listener nats:Listener subscription = new(nats:DEFAULT_URL);
 }
 service nats:Service on subscription {
 
-    remote function onMessage(nats:Message message) {
+    remote function onMessage(nats:AnydataMessage message) {
     }
 
     remote function onError(string message, nats:Error err) {
@@ -35,7 +35,7 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onMessage(nats:Message message) {
+    remote function onMessage(nats:AnydataMessage message) {
     }
 
     remote function onError(nats:Client message, nats:Error err) {

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_12/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_12/service.bal
@@ -23,9 +23,9 @@ listener nats:Listener subscription = new(nats:DEFAULT_URL);
 }
 service nats:Service on subscription {
 
-    remote function onMessage(nats:Message message) {
+    remote function onMessage(nats:AnydataMessage message) {
     }
 
-    remote function onError(nats:Message message) {
+    remote function onError(nats:AnydataMessage message) {
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_13/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_13/service.bal
@@ -23,10 +23,10 @@ listener nats:Listener subscription = new(nats:DEFAULT_URL);
 }
 service nats:Service on subscription {
 
-    remote function onMessage(nats:Message message) {
+    remote function onMessage(nats:AnydataMessage message) {
     }
 
-    remote function onError(nats:Message message, nats:Error err, string something) {
+    remote function onError(nats:AnydataMessage message, nats:Error err, string something) {
     }
 }
 

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_14/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_14/service.bal
@@ -23,10 +23,10 @@ listener nats:Listener subscription = new(nats:DEFAULT_URL);
 }
 service nats:Service on subscription {
 
-    remote function onMessage(nats:Message message) {
+    remote function onMessage(nats:AnydataMessage message) {
     }
 
-    remote function onError(nats:Message message, string err) {
+    remote function onError(nats:AnydataMessage message, string err) {
     }
 }
 
@@ -35,9 +35,9 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onMessage(nats:Message message) {
+    remote function onMessage(nats:AnydataMessage message) {
     }
 
-    remote function onError(nats:Message message, nats:Client err) {
+    remote function onError(nats:AnydataMessage message, nats:Client err) {
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_15/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_15/service.bal
@@ -24,7 +24,7 @@ listener nats:Listener subscription2 = new(nats:DEFAULT_URL);
 }
 service nats:Service on subscription1, subscription2 {
 
-    remote function onMessage(nats:Message message) {
+    remote function onMessage(nats:AnydataMessage message) {
     }
 }
 

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_16/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_16/service.bal
@@ -23,7 +23,7 @@ listener nats:Listener subscription1 = new(nats:DEFAULT_URL);
 }
 service nats:Service on subscription1 {
 
-    remote function onMessage(nats:Message message) {
+    remote function onMessage(nats:AnydataMessage message) {
     }
 
     resource function get greeting() returns string {

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_18/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_18/service.bal
@@ -24,7 +24,7 @@ listener nats:Listener subscription = new(nats:DEFAULT_URL);
 }
 service nats:Service on subscription {
 
-    remote function onMessage(readonly & nats:Message message, string data) {
+    remote function onMessage(readonly & nats:AnydataMessage message, string data) {
     }
 
     remote function onError() {
@@ -36,10 +36,10 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onMessage(nats:Message message, xml data) {
+    remote function onMessage(nats:AnydataMessage message, xml data) {
     }
 
-    remote function onError(nats:Message message) {
+    remote function onError(nats:AnydataMessage message) {
     }
 }
 
@@ -48,7 +48,7 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onMessage(readonly & nats:Message message, decimal[] data) {
+    remote function onMessage(readonly & nats:AnydataMessage message, decimal[] data) {
     }
 
     remote function onError(error err) {

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_19/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_19/service.bal
@@ -24,10 +24,10 @@ listener nats:Listener subscription = new(nats:DEFAULT_URL);
 }
 service nats:Service on subscription {
 
-    remote function onMessage(string data, nats:Message message) {
+    remote function onMessage(string data, nats:AnydataMessage message) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_2/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_2/service.bal
@@ -21,10 +21,10 @@ import ballerinax/nats;
 }
 service nats:Service on new nats:Listener(nats:DEFAULT_URL) {
 
-    remote function onMessage(nats:Message message) {
+    remote function onMessage(nats:AnydataMessage message) {
     }
 
-    remote function onRequest(nats:Message message) returns string {
+    remote function onRequest(nats:AnydataMessage message) returns string {
         return "Hello";
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_20/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_20/service.bal
@@ -24,7 +24,7 @@ listener nats:Listener subscription = new(nats:DEFAULT_URL);
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message, string data) returns string? {
+    remote function onRequest(nats:AnydataMessage message, string data) returns string? {
         return "Hello from the other side";
     }
 
@@ -40,7 +40,7 @@ service nats:Service on subscription {
     remote function onRequest(xml data) returns error? {
     }
 
-    remote function onError(nats:Message message) {
+    remote function onError(nats:AnydataMessage message) {
     }
 }
 
@@ -49,7 +49,7 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(readonly & nats:Message message, decimal[] data) returns anydata {
+    remote function onRequest(readonly & nats:AnydataMessage message, decimal[] data) returns anydata {
         return "Received decimal value";
     }
 

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_21/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_21/service.bal
@@ -27,7 +27,7 @@ service nats:Service on subscription {
     remote function onRequest(string data, xml message) returns error? {
     }
 
-    remote function onError(nats:Message message, nats:Error err) returns error? {
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns error? {
     }
 }
 
@@ -39,7 +39,7 @@ service nats:Service on subscription {
     remote function onRequest(json[] data, int message) returns error? {
     }
 
-    remote function onError(nats:Message message, nats:Error err) returns error? {
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns error? {
     }
 }
 
@@ -51,6 +51,6 @@ service nats:Service on subscription {
     remote function onRequest(readonly & byte[] data, int message) returns error? {
     }
 
-    remote function onError(nats:Message message, nats:Error err) returns error? {
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns error? {
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_22/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_22/service.bal
@@ -24,22 +24,10 @@ listener nats:Listener subscription = new(nats:DEFAULT_URL);
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message1, nats:Message message2) returns error? {
+    remote function onRequest(nats:AnydataMessage message1, nats:AnydataMessage message2) returns error? {
     }
 
-    remote function onError(nats:Message message, nats:Error err) returns error? {
-    }
-}
-
-@nats:ServiceConfig {
-    subject: "demo.bbe.*"
-}
-service nats:Service on subscription {
-
-    remote function onMessage(nats:Message message, nats:Error err) returns error? {
-    }
-
-    remote function onError(nats:Message message, nats:Error err) returns error? {
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns error? {
     }
 }
 
@@ -48,9 +36,21 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message, nats:Client natsClient) returns error? {
+    remote function onMessage(nats:AnydataMessage message, nats:Error err) returns error? {
     }
 
-    remote function onError(nats:Message message, nats:Error err) returns error? {
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns error? {
+    }
+}
+
+@nats:ServiceConfig {
+    subject: "demo.bbe.*"
+}
+service nats:Service on subscription {
+
+    remote function onRequest(nats:AnydataMessage message, nats:Client natsClient) returns error? {
+    }
+
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns error? {
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_23/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_23/service.bal
@@ -27,7 +27,7 @@ service nats:Service on subscription {
     remote function onRequest(nats:Client message, string data) returns error? {
     }
 
-    remote function onError(nats:Message message, nats:Error err) returns error? {
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns error? {
     }
 }
 
@@ -39,6 +39,6 @@ service nats:Service on subscription {
     remote function onMessage(nats:Error err, anydata[] data) returns error? {
     }
 
-    remote function onError(nats:Message message, nats:Error err) returns error? {
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns error? {
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_3/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_3/service.bal
@@ -21,7 +21,7 @@ import ballerinax/nats;
 }
 service nats:Service on new nats:Listener(nats:DEFAULT_URL) {
 
-    remote function onMessage(nats:Message message) {
+    remote function onMessage(nats:AnydataMessage message) {
     }
 
     remote function someFunction() {

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_30/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_30/service.bal
@@ -23,6 +23,6 @@ listener nats:Listener subscription = new(nats:DEFAULT_URL);
 }
 service nats:Service on subscription {
 
-    remote function onMessage(nats:Message message) returns error? {
+    remote function onMessage(nats:AnydataMessage message) returns error? {
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_31/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_31/service.bal
@@ -23,6 +23,6 @@ listener nats:Listener subscription = new(nats:DEFAULT_URL);
 }
 service nats:Service on subscription {
 
-    remote function onMessage(nats:Message message) returns error? {
+    remote function onMessage(nats:AnydataMessage message) returns error? {
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_4/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_4/service.bal
@@ -23,7 +23,7 @@ listener nats:Listener subscription = new(nats:DEFAULT_URL);
 }
 service nats:Service on subscription {
 
-    function onMessage(nats:Message msg) {
+    function onMessage(nats:AnydataMessage msg) {
     }
 }
 
@@ -32,7 +32,7 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    function onRequest(nats:Message msg) {
+    function onRequest(nats:AnydataMessage msg) {
     }
 }
 
@@ -41,9 +41,9 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onMessage(nats:Message msg) {
+    remote function onMessage(nats:AnydataMessage msg) {
     }
 
-    function onError(nats:Message msg, nats:Error err) {
+    function onError(nats:AnydataMessage msg, nats:Error err) {
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_8/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_8/service.bal
@@ -23,7 +23,7 @@ listener nats:Listener subscription = new(nats:DEFAULT_URL);
 }
 service nats:Service on subscription {
 
-    remote function onMessage(nats:Message msg) returns string {
+    remote function onMessage(nats:AnydataMessage msg) returns string {
         return "Invalid return for onMessage";
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_1/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_1/service.bal
@@ -23,7 +23,7 @@ listener nats:Listener subscription = new(nats:DEFAULT_URL);
 }
 service nats:Service on subscription {
 
-    remote function onMessage(nats:Message message) {
+    remote function onMessage(nats:AnydataMessage message) {
     }
 }
 
@@ -32,12 +32,12 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message) {
+    remote function onRequest(nats:AnydataMessage message) {
     }
 }
 
 service "hello" on subscription {
 
-    remote function onRequest(nats:Message message) {
+    remote function onRequest(nats:AnydataMessage message) {
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_10/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_10/service.bal
@@ -26,7 +26,7 @@ service nats:Service on subscription {
     remote function onMessage(string data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 
     function testFunction() {
@@ -41,7 +41,7 @@ service nats:Service on subscription {
     remote function onMessage(xml data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -53,7 +53,7 @@ service nats:Service on subscription {
     remote function onMessage(decimal[] data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -65,7 +65,7 @@ service nats:Service on subscription {
     remote function onMessage(byte[] data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -77,7 +77,7 @@ service nats:Service on subscription {
     remote function onMessage(anydata data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -89,7 +89,7 @@ service nats:Service on subscription {
     remote function onMessage(string[] data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -101,7 +101,7 @@ service nats:Service on subscription {
     remote function onMessage(boolean data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -118,7 +118,7 @@ service nats:Service on subscription {
     remote function onMessage(Employee employee) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -130,7 +130,7 @@ service nats:Service on subscription {
     remote function onMessage(readonly & table<Employee>[] data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -142,7 +142,7 @@ service nats:Service on subscription {
     remote function onMessage(json data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) returns error? {
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns error? {
     }
 }
 
@@ -154,7 +154,7 @@ service nats:Service on subscription {
     remote function onMessage(int[] data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -166,7 +166,7 @@ service nats:Service on subscription {
     remote function onMessage(Employee[] employees) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) returns error? {
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns error? {
     }
 }
 
@@ -178,7 +178,7 @@ service nats:Service on subscription {
     remote function onMessage(json[] data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) returns nats:Error? {
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns nats:Error? {
     }
 }
 
@@ -190,7 +190,7 @@ service nats:Service on subscription {
     remote function onMessage(readonly & xml[] data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -204,6 +204,6 @@ service nats:Service on subscription {
     remote function onMessage(readonly & anydata[] data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_11/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_11/service.bal
@@ -23,7 +23,7 @@ listener nats:Listener subscription = new(nats:DEFAULT_URL);
 }
 service nats:Service on subscription {
 
-    remote function onRequest(readonly & nats:Message message) {
+    remote function onRequest(readonly & nats:AnydataMessage message) {
     }
 }
 
@@ -32,7 +32,7 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message) returns error? {
+    remote function onRequest(nats:AnydataMessage message) returns error? {
     }
 }
 
@@ -41,22 +41,10 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(readonly & nats:Message message, string data) returns anydata|error? {
+    remote function onRequest(readonly & nats:AnydataMessage message, string data) returns anydata|error? {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
-    }
-}
-
-@nats:ServiceConfig {
-    subject: "demo.bbe.*"
-}
-service nats:Service on subscription {
-
-    remote function onRequest(nats:Message message, xml data) returns error? {
-    }
-
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -65,11 +53,23 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(readonly & nats:Message message, decimal[] data) returns string {
+    remote function onRequest(nats:AnydataMessage message, xml data) returns error? {
+    }
+
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
+    }
+}
+
+@nats:ServiceConfig {
+    subject: "demo.bbe.*"
+}
+service nats:Service on subscription {
+
+    remote function onRequest(readonly & nats:AnydataMessage message, decimal[] data) returns string {
         return "Hello back";
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -78,11 +78,11 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message, byte[] data) returns string? {
+    remote function onRequest(nats:AnydataMessage message, byte[] data) returns string? {
         return ();
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -91,11 +91,11 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(readonly & nats:Message message, anydata data) returns xml|error? {
+    remote function onRequest(readonly & nats:AnydataMessage message, anydata data) returns xml|error? {
         return ();
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -104,10 +104,10 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message, string[] data) {
+    remote function onRequest(nats:AnydataMessage message, string[] data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -116,11 +116,11 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(readonly & nats:Message message, boolean data) returns boolean? {
+    remote function onRequest(readonly & nats:AnydataMessage message, boolean data) returns boolean? {
         return false;
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -134,11 +134,11 @@ public type Employee record {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message, Employee employee) returns anydata? {
+    remote function onRequest(nats:AnydataMessage message, Employee employee) returns anydata? {
         return ();
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -147,22 +147,10 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(readonly & nats:Message message, readonly & table<Employee>[] data)  returns error? {
+    remote function onRequest(readonly & nats:AnydataMessage message, readonly & table<Employee>[] data)  returns error? {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
-    }
-}
-
-@nats:ServiceConfig {
-    subject: "demo.bbe.*"
-}
-service nats:Service on subscription {
-
-    remote function onRequest(readonly & nats:Message message, json data) {
-    }
-
-    remote function onError(nats:Message message, nats:Error err) returns error? {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -171,11 +159,23 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message, int[] data) returns string|error? {
+    remote function onRequest(readonly & nats:AnydataMessage message, json data) {
+    }
+
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns error? {
+    }
+}
+
+@nats:ServiceConfig {
+    subject: "demo.bbe.*"
+}
+service nats:Service on subscription {
+
+    remote function onRequest(nats:AnydataMessage message, int[] data) returns string|error? {
         return ();
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -184,11 +184,11 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message, Employee[] employees) returns int|error? {
+    remote function onRequest(nats:AnydataMessage message, Employee[] employees) returns int|error? {
         return 10;
     }
 
-    remote function onError(nats:Message message, nats:Error err) returns error? {
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns error? {
     }
 }
 
@@ -197,10 +197,10 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(readonly & nats:Message message, json[] data) returns error? {
+    remote function onRequest(readonly & nats:AnydataMessage message, json[] data) returns error? {
     }
 
-    remote function onError(nats:Message message, nats:Error err) returns nats:Error? {
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns nats:Error? {
     }
 }
 
@@ -209,11 +209,11 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(readonly & nats:Message message, readonly & xml[] data) returns int|error? {
+    remote function onRequest(readonly & nats:AnydataMessage message, readonly & xml[] data) returns int|error? {
         return ();
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -224,10 +224,10 @@ service nats:Service on subscription {
     private final string var1 = "Service";
     private final int var2 = 54;
 
-    remote function onRequest(readonly & nats:Message message, readonly & anydata[] data) returns anydata {
+    remote function onRequest(readonly & nats:AnydataMessage message, readonly & anydata[] data) returns anydata {
         return 0;
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_12/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_12/service.bal
@@ -26,7 +26,7 @@ service nats:Service on subscription {
     remote function onRequest(string data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 
     function testFunction() {
@@ -41,7 +41,7 @@ service nats:Service on subscription {
     remote function onRequest(xml data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -53,7 +53,7 @@ service nats:Service on subscription {
     remote function onRequest(decimal[] data) returns error? {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -66,7 +66,7 @@ service nats:Service on subscription {
         return "Hello";
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -78,7 +78,7 @@ service nats:Service on subscription {
     remote function onRequest(anydata data) returns nats:Error? {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -91,7 +91,7 @@ service nats:Service on subscription {
         return "Hello Ballerina";
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -103,7 +103,7 @@ service nats:Service on subscription {
     remote function onRequest(boolean data) returns error? {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -120,7 +120,7 @@ service nats:Service on subscription {
     remote function onRequest(Employee employee) returns error? {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -133,7 +133,7 @@ service nats:Service on subscription {
         return ();
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -145,7 +145,7 @@ service nats:Service on subscription {
     remote function onRequest(json data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) returns error? {
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns error? {
     }
 }
 
@@ -158,7 +158,7 @@ service nats:Service on subscription {
         return ();
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -171,7 +171,7 @@ service nats:Service on subscription {
         return 0;
     }
 
-    remote function onError(nats:Message message, nats:Error err) returns error? {
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns error? {
     }
 }
 
@@ -183,7 +183,7 @@ service nats:Service on subscription {
     remote function onRequest(json[] data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) returns nats:Error? {
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns nats:Error? {
     }
 }
 
@@ -196,7 +196,7 @@ service nats:Service on subscription {
         return false;
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -211,6 +211,6 @@ service nats:Service on subscription {
         return ();
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_2/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_2/service.bal
@@ -23,7 +23,7 @@ listener nats:Listener subscription = new(nats:DEFAULT_URL);
 }
 service nats:Service on subscription {
 
-    remote function onMessage(nats:Message message) returns error? {
+    remote function onMessage(nats:AnydataMessage message) returns error? {
     }
 }
 
@@ -32,7 +32,7 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onMessage(nats:Message message) returns ()|error {
+    remote function onMessage(nats:AnydataMessage message) returns ()|error {
     }
 }
 
@@ -41,7 +41,7 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onMessage(nats:Message message) returns nats:Error? {
+    remote function onMessage(nats:AnydataMessage message) returns nats:Error? {
     }
 }
 
@@ -50,6 +50,6 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onMessage(nats:Message message) returns ()|nats:Error {
+    remote function onMessage(nats:AnydataMessage message) returns ()|nats:Error {
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_23/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_23/service.bal
@@ -23,7 +23,7 @@ listener nats:Listener subscription = new(nats:DEFAULT_URL);
 }
 service "demo.bbe" on subscription {
 
-    remote function onMessage(nats:Message message) {
+    remote function onMessage(nats:AnydataMessage message) {
     }
 }
 
@@ -35,7 +35,7 @@ service "demo.bbe" on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onMessage(nats:Message message) {
+    remote function onMessage(nats:AnydataMessage message) {
     }
 }
 

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_3/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_3/service.bal
@@ -23,7 +23,7 @@ listener nats:Listener subscription = new(nats:DEFAULT_URL);
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message) returns error? {
+    remote function onRequest(nats:AnydataMessage message) returns error? {
     }
 }
 
@@ -32,7 +32,7 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message) returns ()|error {
+    remote function onRequest(nats:AnydataMessage message) returns ()|error {
     }
 }
 
@@ -41,7 +41,7 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message) returns nats:Error? {
+    remote function onRequest(nats:AnydataMessage message) returns nats:Error? {
     }
 }
 
@@ -50,7 +50,7 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message) returns ()|nats:Error {
+    remote function onRequest(nats:AnydataMessage message) returns ()|nats:Error {
     }
 }
 
@@ -59,7 +59,7 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message) returns string {
+    remote function onRequest(nats:AnydataMessage message) returns string {
         return "Hello";
     }
 }
@@ -69,7 +69,7 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message) returns string? {
+    remote function onRequest(nats:AnydataMessage message) returns string? {
     }
 }
 
@@ -78,7 +78,7 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message) returns int? {
+    remote function onRequest(nats:AnydataMessage message) returns int? {
     }
 }
 
@@ -87,7 +87,7 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message) returns int {
+    remote function onRequest(nats:AnydataMessage message) returns int {
         return 1;
     }
 }
@@ -97,7 +97,7 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message) returns anydata? {
+    remote function onRequest(nats:AnydataMessage message) returns anydata? {
     }
 }
 
@@ -106,7 +106,7 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message) returns anydata {
+    remote function onRequest(nats:AnydataMessage message) returns anydata {
     }
 }
 
@@ -115,7 +115,7 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message) returns anydata|error {
+    remote function onRequest(nats:AnydataMessage message) returns anydata|error {
     }
 }
 
@@ -124,7 +124,7 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message) returns error|anydata {
+    remote function onRequest(nats:AnydataMessage message) returns error|anydata {
     }
 }
 
@@ -133,7 +133,7 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message) returns string|error {
+    remote function onRequest(nats:AnydataMessage message) returns string|error {
         return "Hello";
     }
 }
@@ -143,7 +143,7 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message) returns error|string {
+    remote function onRequest(nats:AnydataMessage message) returns error|string {
         return "Hello";
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_4/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_4/service.bal
@@ -23,22 +23,10 @@ listener nats:Listener subscription = new(nats:DEFAULT_URL);
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message) returns error? {
+    remote function onRequest(nats:AnydataMessage message) returns error? {
     }
 
-    remote function onError(nats:Message message, nats:Error err) returns error? {
-    }
-}
-
-@nats:ServiceConfig {
-    subject: "demo.bbe.*"
-}
-service nats:Service on subscription {
-
-    remote function onRequest(nats:Message message) returns error? {
-    }
-
-    remote function onError(nats:Message message, nats:Error err) returns ()|nats:Error {
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns error? {
     }
 }
 
@@ -47,10 +35,10 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message) returns error? {
+    remote function onRequest(nats:AnydataMessage message) returns error? {
     }
 
-    remote function onError(nats:Message message, nats:Error err) returns nats:Error? {
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns ()|nats:Error {
     }
 }
 
@@ -59,9 +47,21 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onRequest(nats:Message message) returns error? {
+    remote function onRequest(nats:AnydataMessage message) returns error? {
     }
 
-    remote function onError(nats:Message message, nats:Error err) returns ()|error {
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns nats:Error? {
+    }
+}
+
+@nats:ServiceConfig {
+    subject: "demo.bbe.*"
+}
+service nats:Service on subscription {
+
+    remote function onRequest(nats:AnydataMessage message) returns error? {
+    }
+
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns ()|error {
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_5/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_5/service.bal
@@ -22,5 +22,5 @@ listener foo:Listener subscription = new(foo:DEFAULT_URL);
     subject: "demo.bbe.*"
 }
 service foo:Service on subscription {
-    remote function onMessage(foo:Message data) {}
+    remote function onMessage(foo:AnydataMessage data) {}
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_6/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_6/service.bal
@@ -17,7 +17,7 @@
 import ballerinax/nats;
 
 listener nats:Listener subscription = new(nats:DEFAULT_URL);
-type Foo nats:Message;
+type Foo nats:AnydataMessage;
 
 @nats:ServiceConfig {
     subject: "demo.bbe.*"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_7/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_7/service.bal
@@ -24,7 +24,7 @@ listener nats:Listener subscription = new(nats:DEFAULT_URL);
 service nats:Service on subscription {
     nats:Client natsClient = checkpanic new(nats:DEFAULT_URL);
 
-    remote function onMessage(nats:Message message) {
+    remote function onMessage(nats:AnydataMessage message) {
     }
 }
 
@@ -34,6 +34,6 @@ service nats:Service on subscription {
 service nats:Service on subscription {
     string hello = "Hello";
 
-    remote function onRequest(nats:Message message) {
+    remote function onRequest(nats:AnydataMessage message) {
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_8/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_8/service.bal
@@ -23,6 +23,6 @@ listener nats:Listener subscription = new(nats:DEFAULT_URL);
 }
 service nats:Service on subscription {
 
-    remote function onMessage(readonly & nats:Message message) {
+    remote function onMessage(readonly & nats:AnydataMessage message) {
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_9/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_9/service.bal
@@ -23,7 +23,7 @@ listener nats:Listener subscription = new(nats:DEFAULT_URL);
 }
 service nats:Service on subscription {
 
-    remote function onMessage(readonly & nats:Message message) {
+    remote function onMessage(readonly & nats:AnydataMessage message) {
     }
 }
 
@@ -32,7 +32,7 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onMessage(nats:Message message) returns error? {
+    remote function onMessage(nats:AnydataMessage message) returns error? {
     }
 }
 
@@ -41,22 +41,10 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onMessage(readonly & nats:Message message, string data) {
+    remote function onMessage(readonly & nats:AnydataMessage message, string data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
-    }
-}
-
-@nats:ServiceConfig {
-    subject: "demo.bbe.*"
-}
-service nats:Service on subscription {
-
-    remote function onMessage(nats:Message message, xml data) {
-    }
-
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -65,22 +53,10 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onMessage(readonly & nats:Message message, decimal[] data) {
+    remote function onMessage(nats:AnydataMessage message, xml data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
-    }
-}
-
-@nats:ServiceConfig {
-    subject: "demo.bbe.*"
-}
-service nats:Service on subscription {
-
-    remote function onMessage(nats:Message message, byte[] data) {
-    }
-
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -89,22 +65,10 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onMessage(readonly & nats:Message message, anydata data) {
+    remote function onMessage(readonly & nats:AnydataMessage message, decimal[] data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
-    }
-}
-
-@nats:ServiceConfig {
-    subject: "demo.bbe.*"
-}
-service nats:Service on subscription {
-
-    remote function onMessage(nats:Message message, string[] data) {
-    }
-
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -113,10 +77,46 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onMessage(readonly & nats:Message message, boolean data) {
+    remote function onMessage(nats:AnydataMessage message, byte[] data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
+    }
+}
+
+@nats:ServiceConfig {
+    subject: "demo.bbe.*"
+}
+service nats:Service on subscription {
+
+    remote function onMessage(readonly & nats:AnydataMessage message, anydata data) {
+    }
+
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
+    }
+}
+
+@nats:ServiceConfig {
+    subject: "demo.bbe.*"
+}
+service nats:Service on subscription {
+
+    remote function onMessage(nats:AnydataMessage message, string[] data) {
+    }
+
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
+    }
+}
+
+@nats:ServiceConfig {
+    subject: "demo.bbe.*"
+}
+service nats:Service on subscription {
+
+    remote function onMessage(readonly & nats:AnydataMessage message, boolean data) {
+    }
+
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -130,22 +130,10 @@ public type Employee record {
 }
 service nats:Service on subscription {
 
-    remote function onMessage(nats:Message message, Employee employee) {
+    remote function onMessage(nats:AnydataMessage message, Employee employee) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
-    }
-}
-
-@nats:ServiceConfig {
-    subject: "demo.bbe.*"
-}
-service nats:Service on subscription {
-
-    remote function onMessage(readonly & nats:Message message, readonly & table<Employee>[] data) {
-    }
-
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -154,22 +142,10 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onMessage(readonly & nats:Message message, json data) {
+    remote function onMessage(readonly & nats:AnydataMessage message, readonly & table<Employee>[] data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) returns error? {
-    }
-}
-
-@nats:ServiceConfig {
-    subject: "demo.bbe.*"
-}
-service nats:Service on subscription {
-
-    remote function onMessage(nats:Message message, int[] data) {
-    }
-
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -178,22 +154,10 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onMessage(nats:Message message, Employee[] employees) {
+    remote function onMessage(readonly & nats:AnydataMessage message, json data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) returns error? {
-    }
-}
-
-@nats:ServiceConfig {
-    subject: "demo.bbe.*"
-}
-service nats:Service on subscription {
-
-    remote function onMessage(readonly & nats:Message message, json[] data) {
-    }
-
-    remote function onError(nats:Message message, nats:Error err) returns nats:Error? {
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns error? {
     }
 }
 
@@ -202,10 +166,46 @@ service nats:Service on subscription {
 }
 service nats:Service on subscription {
 
-    remote function onMessage(readonly & nats:Message message, readonly & xml[] data) {
+    remote function onMessage(nats:AnydataMessage message, int[] data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
+    }
+}
+
+@nats:ServiceConfig {
+    subject: "demo.bbe.*"
+}
+service nats:Service on subscription {
+
+    remote function onMessage(nats:AnydataMessage message, Employee[] employees) {
+    }
+
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns error? {
+    }
+}
+
+@nats:ServiceConfig {
+    subject: "demo.bbe.*"
+}
+service nats:Service on subscription {
+
+    remote function onMessage(readonly & nats:AnydataMessage message, json[] data) {
+    }
+
+    remote function onError(nats:AnydataMessage message, nats:Error err) returns nats:Error? {
+    }
+}
+
+@nats:ServiceConfig {
+    subject: "demo.bbe.*"
+}
+service nats:Service on subscription {
+
+    remote function onMessage(readonly & nats:AnydataMessage message, readonly & xml[] data) {
+    }
+
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }
 
@@ -216,9 +216,9 @@ service nats:Service on subscription {
     private final string var1 = "Service";
     private final int var2 = 54;
 
-    remote function onMessage(readonly & nats:Message message, readonly & anydata[] data) {
+    remote function onMessage(readonly & nats:AnydataMessage message, readonly & anydata[] data) {
     }
 
-    remote function onError(nats:Message message, nats:Error err) {
+    remote function onError(nats:AnydataMessage message, nats:Error err) {
     }
 }

--- a/compiler-plugin-tests/src/test/resources/expected_sources/service_1/result.bal
+++ b/compiler-plugin-tests/src/test/resources/expected_sources/service_1/result.bal
@@ -3,7 +3,7 @@ import ballerinax/nats;
 listener nats:Listener subscription = new(nats:DEFAULT_URL);
 
 service "demo" on subscription {
-	remote function onMessage(nats:Message message) returns nats:Error? {
+	remote function onMessage(nats:AnydataMessage message) returns nats:Error? {
 
 	}
 }

--- a/compiler-plugin-tests/src/test/resources/expected_sources/service_2/result.bal
+++ b/compiler-plugin-tests/src/test/resources/expected_sources/service_2/result.bal
@@ -5,7 +5,7 @@ listener nats:Listener subscription = new(nats:DEFAULT_URL);
 service "demo" on subscription {
     int x = 5;
     string y = "xx";
-	remote function onMessage(nats:Message message) returns nats:Error? {
+	remote function onMessage(nats:AnydataMessage message) returns nats:Error? {
 
 	}
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/nats/plugin/NatsCodeTemplate.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/nats/plugin/NatsCodeTemplate.java
@@ -48,7 +48,7 @@ public class NatsCodeTemplate implements CodeAction {
 
     public static final String NODE_LOCATION = "node.location";
     public static final String LS = System.lineSeparator();
-    public static final String REMOTE_FUNCTION_TEXT = LS + "\tremote function onMessage(nats:Message message)" +
+    public static final String REMOTE_FUNCTION_TEXT = LS + "\tremote function onMessage(nats:AnydataMessage message)" +
             " returns nats:Error? {" + LS + LS + "\t}" + LS;
 
     @Override

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/nats/plugin/PluginConstants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/nats/plugin/PluginConstants.java
@@ -34,8 +34,6 @@ public class PluginConstants {
     public static final String MESSAGE_SUBJECT = "subject";
     public static final String MESSAGE_REPLY_TO = "replyTo";
 
-    // parameters
-    public static final String MESSAGE = "Message";
     public static final String ERROR_PARAM = "Error";
 
     // return types error or nil
@@ -54,7 +52,7 @@ public class PluginConstants {
         INVALID_RESOURCE_FUNCTION("Resource functions not allowed", "NATS_103"),
         FUNCTION_SHOULD_BE_REMOTE("Method must have the remote qualifier.", "NATS_104"),
         MUST_HAVE_MESSAGE_OR_ANYDATA("Must have the method parameter nats:AnydataMessage or anydata.", "NATS_105"),
-        MUST_HAVE_MESSAGE_AND_ERROR("Must have the method parameters nats:Message and nats:Error.", "NATS_106"),
+        MUST_HAVE_MESSAGE_AND_ERROR("Must have the method parameters nats:AnydataMessage and nats:Error.", "NATS_106"),
         INVALID_FUNCTION("Resource functions are not allowed.", "NATS_107"),
         INVALID_FUNCTION_PARAM_MESSAGE("Invalid method parameter. Only subtypes of nats:AnydataMessage " +
                 "or anydata is allowed.", "NATS_108"),

--- a/docs/proposals/data-binding.md
+++ b/docs/proposals/data-binding.md
@@ -45,7 +45,7 @@ When receiving the same message,
 ```ballerina
 service "demo" on new nats:Listener(nats:DEFAULT_URL) {
 
-    remote function onMessage(nats:Message message) returns nats:Error? {
+    remote function onMessage(nats:AnydataMessage message) returns nats:Error? {
         string messageContent = check string:fromBytes(message.content);
         Person person = check value:fromJsonStringWithType(messageContent);
     }
@@ -56,7 +56,7 @@ Receiving the message as a request,
 ```ballerina
 service "demo" on new nats:Listener(nats:DEFAULT_URL) {
 
-    remote function onRequest(nats:Message message) returns anydata|nats:Error? {
+    remote function onRequest(nats:AnydataMessage message) returns anydata|nats:Error? {
         string messageContent = check string:fromBytes(message.content);
         Person person = check value:fromJsonStringWithType(messageContent);
         return "New person received";

--- a/examples/order-manager/notification-service/notification_service.bal
+++ b/examples/order-manager/notification-service/notification_service.bal
@@ -27,7 +27,7 @@ configurable string LISTENING_SUBJECT = ?;
 service "notificationService" on new nats:Listener(nats:DEFAULT_URL) {
 
     // Listens to NATS subject for any successful orders
-    remote function onMessage(nats:Message message) returns error? {
+    remote function onMessage(nats:BytesMessage message) returns error? {
 
         // Convert the byte values in the NATS Message to type Order
         string messageContent = check string:fromBytes(message.content);

--- a/examples/order-manager/order-processor/order_processor.bal
+++ b/examples/order-manager/order-processor/order_processor.bal
@@ -30,7 +30,7 @@ service "orderProcessorService" on new nats:Listener(nats:DEFAULT_URL) {
     nats:Client natsClient = checkpanic new(nats:DEFAULT_URL);
 
     // Listens to NATS subject for any new orders and process them
-    remote function onMessage(nats:Message message) returns error? {
+    remote function onMessage(nats:BytesMessage message) returns error? {
 
         // Uses Ballerina query expressions to filter out the successful orders and publish to NATS subject
         check from types:Order 'order in check getOrdersFromMessage(message)
@@ -48,7 +48,7 @@ service "orderProcessorService" on new nats:Listener(nats:DEFAULT_URL) {
 }
 
 // Convert the byte values in NATS message to type Order[]
-function getOrdersFromMessage(nats:Message message) returns types:Order[]|error {
+function getOrdersFromMessage(nats:BytesMessage message) returns types:Order[]|error {
     types:Order[] receivedOrders = [];
     string messageContent = check string:fromBytes(message.content);
     json jsonContent = check value:fromJsonString(messageContent);

--- a/examples/order-manager/order-processor/tests/order_processor_tests.bal
+++ b/examples/order-manager/order-processor/tests/order_processor_tests.bal
@@ -66,7 +66,7 @@ nats:Service consumerService =
     subject: PUBLISH_SUBJECT
 }
 service object {
-    remote function onMessage(nats:Message msg) {
+    remote function onMessage(nats:BytesMessage msg) {
         byte[] messageContent = <@untainted> msg.content;
 
         string|error message = string:fromBytes(messageContent);

--- a/examples/order-manager/order-service/tests/order_service_tests.bal
+++ b/examples/order-manager/order-service/tests/order_service_tests.bal
@@ -76,7 +76,7 @@ nats:Service consumerService =
     subject: SUBJECT
 }
 service object {
-    remote function onMessage(nats:Message msg) {
+    remote function onMessage(nats:BytesMessage msg) {
         byte[] messageContent = <@untainted> msg.content;
 
         string|error message = strings:fromBytes(messageContent);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
 
-version=2.11.0-SNAPSHOT
+version=3.0.0-SNAPSHOT
 ballerinaLangVersion=2201.8.0
 ballerinaGradlePluginVersion=2.0.1
 

--- a/load-tests/simple_producer_consumer/src/main.bal
+++ b/load-tests/simple_producer_consumer/src/main.bal
@@ -125,7 +125,7 @@ nats:Service natsService =
     subject: SUBJECT
 }
 service object {
-    remote function onMessage(nats:Message message) returns error? {
+    remote function onMessage(nats:BytesMessage message) returns error? {
         string|error messageContent = 'string:fromBytes(message.content);
         if messageContent is error {
             lock {

--- a/native/src/main/java/io/ballerina/stdlib/nats/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/nats/Constants.java
@@ -73,7 +73,7 @@ public class Constants {
     public static final String SERVICE_LIST = "service_list";
 
     // Represents the message which will be consumed from NATS.
-    public static final String NATS_MESSAGE_OBJ_NAME = "Message";
+    public static final String NATS_MESSAGE_OBJ_NAME = "AnydataMessage";
     public static final String MESSAGE_CONTENT = "content";
     public static final String MESSAGE_SUBJECT = "subject";
     public static final String MESSAGE_REPLY_TO = "replyTo";

--- a/native/src/main/java/io/ballerina/stdlib/nats/Utils.java
+++ b/native/src/main/java/io/ballerina/stdlib/nats/Utils.java
@@ -130,13 +130,6 @@ public class Utils {
         return recordType;
     }
 
-    public static RecordType getRecordType(Type type) {
-        if (type.getTag() == TypeTags.INTERSECTION_TAG) {
-            return (RecordType) TypeUtils.getReferredType(((IntersectionType) (type)).getConstituentTypes().get(0));
-        }
-        return (RecordType) type;
-    }
-
     public static Object getValueWithIntendedType(Type type, byte[] value) throws BError {
         String strValue = new String(value, StandardCharsets.UTF_8);
         try {

--- a/native/src/main/java/io/ballerina/stdlib/nats/basic/consumer/DefaultMessageHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/nats/basic/consumer/DefaultMessageHandler.java
@@ -342,7 +342,7 @@ public class DefaultMessageHandler implements MessageHandler {
 
     private static Type getPayloadType(Type definedType) {
         if (definedType.getTag() == INTERSECTION_TAG) {
-            return ((IntersectionType) definedType).getConstituentTypes().get(0);
+            return TypeUtils.getReferredType(definedType);
         }
         return definedType;
     }


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/6282

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [ ] Added tests
- [x] Updated the spec
- [ ] Checked native-image compatibility
